### PR TITLE
avoid race condition in float::exp, float::log.

### DIFF
--- a/ifloat.hh
+++ b/ifloat.hh
@@ -958,8 +958,8 @@ template <typename T, typename W, int bits, typename U> SimpleFloat<T,W,bits,U> 
     }
     return res;
   }
-  const auto& ea(exparray());
-  const auto& iea(invexparray());
+  static const auto& ea(exparray());
+  static const auto& iea(invexparray());
         auto  result(zero());
         auto  work(*this);
   if(one_einv < work) {
@@ -1006,8 +1006,8 @@ template <typename T, typename W, int bits, typename U> SimpleFloat<T,W,bits,U> 
     }
     return res;
   }
-  const auto& en(exparray());
-  const auto& ien(invexparray());
+  static const auto& en(exparray());
+  static const auto& ien(invexparray());
         auto  work(this->abs());
         auto  result(one());
   for(int i = 1; 0 <= i && i < min(en.size(), ien.size()) && work.floor(); i ++, work >>= U(1))


### PR DESCRIPTION
if we're not lucky on compiler, this has also glitches on the implementation.